### PR TITLE
Update index.coffee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
-{   "name": "mongoose-thumbnail"
+{   "name": "mg-mongoose-thumbnail"
   , "description": "Mongoose plugin adding a thumbnail field to a schema - useful for expressjs image file uploads"
-  , "version": "0.0.1"
-  , "homepage": "https://github.com/panta/mongoose-thumbnail"
-  , "author": "Marco Pantaleoni <marco.pantaleoni@gmail.com>"
+  , "version": "0.0.2"
+  , "homepage": "https://github.com/Yablargo/mongoose-thumbnail"
+  , "author": "Matthew Galligan (matthew.galligan@gmail.com) forked from Marco Pantaleoni <marco.pantaleoni@gmail.com>"
   , "dependencies": {
       "mongoose": ">= 3.0.1"
     , "mkdirp": ">= 0.3.4"
@@ -20,10 +20,10 @@
   , "keywords": ["mongoose", "plugin", "plugins", "types", "image", "picture", "thumbnail", "file", "upload", "express"]
   , "repository": {
       "type": "git"
-    , "url": "git://github.com/panta/mongoose-thumbnail.git"
+    , "url": "git://github.com/Yablargo/mongoose-thumbnail.git"
   }
   , "bugs": {
-    "url" : "https://github.com/panta/mongoose-thumbnail/issues"
+    "url" : "https://github.com/Yablargo/mongoose-thumbnail/issues"
   }
   , "licenses": [{ 
       "type": "MIT", 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -85,6 +85,13 @@ thumbnailPlugin = (schema, options={}) ->
       width: size
       format: format
       filter: 'Lanczos'     # 'Lagrange'
+    #If a size contains ">" character, e.g. 64>, apply both to size and width. This allows a user to specify 
+    #Size: "64>" which will resize the largest size to 64.
+    #A better approach would probably be to make sure it ends with > and check for e.g. ^> 
+    if size.contains and size.contains(">")
+      im_resize_opts.width = size
+      im_resize_opts.height = size
+
     if modeInline
       im_resize_opts.srcData = fs.readFileSync image_path, 'binary'
     else


### PR DESCRIPTION
 If a size contains ">" character, e.g. 64>, apply both to size and width. This allows a user to specify e.g. Size: "64>" which will resize the largest size to 64. A better approach would probably be to make sure it ends with > and check for e.g. ^>

When using this plugin, I can create for example a 64 width 2000 height jpg, which will not get shrunk in the current implementation of "size" parameter. I made this change to fix the problem on my end.
Passing e.g. "64>" now resizes the largest side to 64px
